### PR TITLE
Fixed docker-compose server/client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,4 +16,4 @@ services:
         working_dir: /project/src
         command: >
           bash -c "/opt/conda/bin/pip3 install -r /project/requirements.txt
-          && /opt/conda/bin/python3 main.py server"
+          && /opt/conda/bin/python3 main.py client"


### PR DESCRIPTION
The docker compose file should start the `main.py` file once with the `server` argument and another one with the `client` argument.

This should fix the client container which actually started as a `server`